### PR TITLE
feat(spms): add instruction management module for syllabus and lessons

### DIFF
--- a/api/db.js
+++ b/api/db.js
@@ -27,6 +27,10 @@ async function ensureIndexes(db) {
   await db.collection('sections').createIndex({ year_level: 1, section: 1 }, { unique: true })
   await db.collection('skills').createIndex({ name: 1, category: 1 }, { unique: true })
   await db.collection('student_skills').createIndex({ student_id: 1, skill_id: 1 }, { unique: true })
+  await db.collection('syllabi').createIndex({ syllabus_id: 1 }, { unique: true })
+  await db.collection('syllabi').createIndex({ title: 1 })
+  await db.collection('lessons').createIndex({ lesson_id: 1 }, { unique: true })
+  await db.collection('lessons').createIndex({ syllabus_id: 1, order_index: 1 })
 }
 
 export async function getDb() {

--- a/api/index.js
+++ b/api/index.js
@@ -85,6 +85,13 @@ function requireStaff(req, res, next) {
   return next()
 }
 
+function requireInstructionEditor(req, res, next) {
+  if (req.auth?.role !== 'admin' && req.auth?.role !== 'faculty') {
+    return res.status(403).json({ message: 'Forbidden' })
+  }
+  return next()
+}
+
 app.post('/api/login', async (req, res) => {
   const parsed = loginSchema.safeParse(req.body)
   if (!parsed.success) {
@@ -547,6 +554,241 @@ app.get('/api/qualification-reports', authMiddleware, requireStaff, async (req, 
     category: categoryRaw || 'all',
     students: Array.from(map.values()),
   })
+})
+
+const syllabusSchema = z.object({
+  title: z.string().trim().min(1).max(200),
+  description: z.string().trim().max(4000).optional().default(''),
+  course_code: z.string().trim().max(50).optional().default(''),
+})
+
+const syllabusUpdateSchema = z.object({
+  title: z.string().trim().min(1).max(200).optional(),
+  description: z.string().trim().max(4000).optional(),
+  course_code: z.string().trim().max(50).optional(),
+  is_archived: z.number().int().min(0).max(1).optional(),
+})
+
+const lessonSchema = z.object({
+  syllabus_id: z.number().int().positive(),
+  title: z.string().trim().min(1).max(220),
+  content: z.string().trim().max(12000).optional().default(''),
+  curriculum_unit: z.string().trim().max(120).optional().default(''),
+  week_number: z.number().int().min(1).max(52).optional().nullable(),
+  order_index: z.number().int().min(1).max(1000).optional(),
+})
+
+const lessonUpdateSchema = z.object({
+  title: z.string().trim().min(1).max(220).optional(),
+  content: z.string().trim().max(12000).optional(),
+  curriculum_unit: z.string().trim().max(120).optional(),
+  week_number: z.number().int().min(1).max(52).optional().nullable(),
+  order_index: z.number().int().min(1).max(1000).optional(),
+  is_archived: z.number().int().min(0).max(1).optional(),
+})
+
+const curriculumReorderSchema = z.object({
+  lessons: z.array(
+    z.object({
+      lesson_id: z.number().int().positive(),
+      order_index: z.number().int().min(1).max(1000),
+      curriculum_unit: z.string().trim().max(120).optional(),
+      week_number: z.number().int().min(1).max(52).optional().nullable(),
+    }),
+  ),
+})
+
+app.get('/api/instruction/syllabi', authMiddleware, async (req, res) => {
+  const db = await getDb()
+  const includeArchived = String(req.query.includeArchived || '').toLowerCase() === 'true'
+  const query = includeArchived ? {} : { is_archived: { $ne: 1 } }
+  const syllabi = await db
+    .collection('syllabi')
+    .find(query, { projection: { _id: 0 } })
+    .sort({ created_at: -1 })
+    .toArray()
+  return res.json({ syllabi })
+})
+
+app.post('/api/instruction/syllabi', authMiddleware, requireInstructionEditor, async (req, res) => {
+  const parsed = syllabusSchema.safeParse(req.body)
+  if (!parsed.success) return res.status(400).json({ message: 'Invalid input' })
+  const db = await getDb()
+  const created = {
+    syllabus_id: await nextSequence(db, 'syllabi'),
+    title: parsed.data.title,
+    description: parsed.data.description,
+    course_code: parsed.data.course_code,
+    is_archived: 0,
+    created_by: Number(req.auth?.sub) || null,
+    created_at: new Date(),
+    updated_at: new Date(),
+  }
+  await db.collection('syllabi').insertOne(created)
+  return res.status(201).json({ syllabus: created })
+})
+
+app.put('/api/instruction/syllabi/:id', authMiddleware, requireInstructionEditor, async (req, res) => {
+  const id = Number(req.params.id)
+  if (!id) return res.status(400).json({ message: 'Invalid syllabus id' })
+  const parsed = syllabusUpdateSchema.safeParse(req.body)
+  if (!parsed.success) return res.status(400).json({ message: 'Invalid input' })
+
+  const fields = {}
+  if (parsed.data.title !== undefined) fields.title = parsed.data.title
+  if (parsed.data.description !== undefined) fields.description = parsed.data.description
+  if (parsed.data.course_code !== undefined) fields.course_code = parsed.data.course_code
+  if (parsed.data.is_archived !== undefined) fields.is_archived = parsed.data.is_archived
+  fields.updated_at = new Date()
+  if (Object.keys(fields).length === 1) return res.status(400).json({ message: 'No fields to update' })
+
+  const db = await getDb()
+  const existing = await db.collection('syllabi').findOne({ syllabus_id: id }, { projection: { _id: 0, syllabus_id: 1 } })
+  if (!existing) return res.status(404).json({ message: 'Syllabus not found' })
+  await db.collection('syllabi').updateOne({ syllabus_id: id }, { $set: fields })
+  const updated = await db.collection('syllabi').findOne({ syllabus_id: id }, { projection: { _id: 0 } })
+  return res.json({ syllabus: updated })
+})
+
+app.delete('/api/instruction/syllabi/:id', authMiddleware, requireInstructionEditor, async (req, res) => {
+  const id = Number(req.params.id)
+  if (!id) return res.status(400).json({ message: 'Invalid syllabus id' })
+  const db = await getDb()
+  const existing = await db.collection('syllabi').findOne({ syllabus_id: id }, { projection: { _id: 0, syllabus_id: 1 } })
+  if (!existing) return res.status(404).json({ message: 'Syllabus not found' })
+
+  const hardDelete = req.auth?.role === 'admin' && String(req.query.hard || '').toLowerCase() === 'true'
+  if (hardDelete) {
+    await db.collection('lessons').deleteMany({ syllabus_id: id })
+    await db.collection('syllabi').deleteOne({ syllabus_id: id })
+    return res.json({ ok: true, mode: 'deleted' })
+  }
+
+  await db.collection('syllabi').updateOne({ syllabus_id: id }, { $set: { is_archived: 1, updated_at: new Date() } })
+  await db.collection('lessons').updateMany({ syllabus_id: id }, { $set: { is_archived: 1, updated_at: new Date() } })
+  return res.json({ ok: true, mode: 'archived' })
+})
+
+app.get('/api/instruction/syllabi/:id/lessons', authMiddleware, async (req, res) => {
+  const id = Number(req.params.id)
+  if (!id) return res.status(400).json({ message: 'Invalid syllabus id' })
+  const includeArchived = String(req.query.includeArchived || '').toLowerCase() === 'true'
+  const query = includeArchived ? { syllabus_id: id } : { syllabus_id: id, is_archived: { $ne: 1 } }
+  const db = await getDb()
+  const syllabus = await db.collection('syllabi').findOne({ syllabus_id: id }, { projection: { _id: 0 } })
+  if (!syllabus) return res.status(404).json({ message: 'Syllabus not found' })
+  const lessons = await db
+    .collection('lessons')
+    .find(query, { projection: { _id: 0 } })
+    .sort({ order_index: 1, lesson_id: 1 })
+    .toArray()
+  return res.json({ syllabus, lessons })
+})
+
+app.post('/api/instruction/lessons', authMiddleware, requireInstructionEditor, async (req, res) => {
+  const parsed = lessonSchema.safeParse(req.body)
+  if (!parsed.success) return res.status(400).json({ message: 'Invalid input' })
+  const db = await getDb()
+  const syllabus = await db.collection('syllabi').findOne(
+    { syllabus_id: parsed.data.syllabus_id, is_archived: { $ne: 1 } },
+    { projection: { _id: 0, syllabus_id: 1 } },
+  )
+  if (!syllabus) return res.status(404).json({ message: 'Syllabus not found or archived' })
+
+  let orderIndex = parsed.data.order_index
+  if (!orderIndex) {
+    const last = await db
+      .collection('lessons')
+      .find({ syllabus_id: parsed.data.syllabus_id }, { projection: { _id: 0, order_index: 1 } })
+      .sort({ order_index: -1 })
+      .limit(1)
+      .toArray()
+    orderIndex = (last[0]?.order_index ?? 0) + 1
+  }
+
+  const lesson = {
+    lesson_id: await nextSequence(db, 'lessons'),
+    syllabus_id: parsed.data.syllabus_id,
+    title: parsed.data.title,
+    content: parsed.data.content,
+    curriculum_unit: parsed.data.curriculum_unit,
+    week_number: parsed.data.week_number ?? null,
+    order_index: orderIndex,
+    is_archived: 0,
+    created_by: Number(req.auth?.sub) || null,
+    created_at: new Date(),
+    updated_at: new Date(),
+  }
+  await db.collection('lessons').insertOne(lesson)
+  return res.status(201).json({ lesson })
+})
+
+app.put('/api/instruction/lessons/:id', authMiddleware, requireInstructionEditor, async (req, res) => {
+  const id = Number(req.params.id)
+  if (!id) return res.status(400).json({ message: 'Invalid lesson id' })
+  const parsed = lessonUpdateSchema.safeParse(req.body)
+  if (!parsed.success) return res.status(400).json({ message: 'Invalid input' })
+  const fields = {}
+  if (parsed.data.title !== undefined) fields.title = parsed.data.title
+  if (parsed.data.content !== undefined) fields.content = parsed.data.content
+  if (parsed.data.curriculum_unit !== undefined) fields.curriculum_unit = parsed.data.curriculum_unit
+  if (parsed.data.week_number !== undefined) fields.week_number = parsed.data.week_number
+  if (parsed.data.order_index !== undefined) fields.order_index = parsed.data.order_index
+  if (parsed.data.is_archived !== undefined) fields.is_archived = parsed.data.is_archived
+  fields.updated_at = new Date()
+  if (Object.keys(fields).length === 1) return res.status(400).json({ message: 'No fields to update' })
+  const db = await getDb()
+  const existing = await db.collection('lessons').findOne({ lesson_id: id }, { projection: { _id: 0, lesson_id: 1 } })
+  if (!existing) return res.status(404).json({ message: 'Lesson not found' })
+  await db.collection('lessons').updateOne({ lesson_id: id }, { $set: fields })
+  const updated = await db.collection('lessons').findOne({ lesson_id: id }, { projection: { _id: 0 } })
+  return res.json({ lesson: updated })
+})
+
+app.delete('/api/instruction/lessons/:id', authMiddleware, requireInstructionEditor, async (req, res) => {
+  const id = Number(req.params.id)
+  if (!id) return res.status(400).json({ message: 'Invalid lesson id' })
+  const db = await getDb()
+  const existing = await db.collection('lessons').findOne({ lesson_id: id }, { projection: { _id: 0, lesson_id: 1 } })
+  if (!existing) return res.status(404).json({ message: 'Lesson not found' })
+  const hardDelete = req.auth?.role === 'admin' && String(req.query.hard || '').toLowerCase() === 'true'
+  if (hardDelete) {
+    await db.collection('lessons').deleteOne({ lesson_id: id })
+    return res.json({ ok: true, mode: 'deleted' })
+  }
+  await db.collection('lessons').updateOne({ lesson_id: id }, { $set: { is_archived: 1, updated_at: new Date() } })
+  return res.json({ ok: true, mode: 'archived' })
+})
+
+app.put('/api/instruction/syllabi/:id/curriculum', authMiddleware, requireInstructionEditor, async (req, res) => {
+  const id = Number(req.params.id)
+  if (!id) return res.status(400).json({ message: 'Invalid syllabus id' })
+  const parsed = curriculumReorderSchema.safeParse(req.body)
+  if (!parsed.success) return res.status(400).json({ message: 'Invalid input' })
+  const db = await getDb()
+  const syllabus = await db.collection('syllabi').findOne({ syllabus_id: id }, { projection: { _id: 0, syllabus_id: 1 } })
+  if (!syllabus) return res.status(404).json({ message: 'Syllabus not found' })
+
+  for (const entry of parsed.data.lessons) {
+    await db.collection('lessons').updateOne(
+      { lesson_id: entry.lesson_id, syllabus_id: id },
+      {
+        $set: {
+          order_index: entry.order_index,
+          curriculum_unit: entry.curriculum_unit ?? '',
+          week_number: entry.week_number ?? null,
+          updated_at: new Date(),
+        },
+      },
+    )
+  }
+
+  const lessons = await db
+    .collection('lessons')
+    .find({ syllabus_id: id, is_archived: { $ne: 1 } }, { projection: { _id: 0 } })
+    .sort({ order_index: 1, lesson_id: 1 })
+    .toArray()
+  return res.json({ lessons })
 })
 
 app.get('/api/health', (_req, res) => res.json({ ok: true }))

--- a/src/spms/auth/authService.ts
+++ b/src/spms/auth/authService.ts
@@ -85,7 +85,7 @@ export function logout(): void {
 export function getAllowedPaths(role: UserRole): string[] {
   switch (role) {
     case 'admin':
-      return ['/', '/registrar', '/students', '/reports', '/medical']
+      return ['/', '/registrar', '/students', '/reports', '/medical', '/instruction']
     case 'faculty':
       return [
         '/',
@@ -99,9 +99,10 @@ export function getAllowedPaths(role: UserRole): string[] {
         '/medical',
         '/students',
         '/reports',
+        '/instruction',
       ]
     case 'student':
-      return ['/', '/student', '/student/medical', '/medical']
+      return ['/', '/student', '/student/medical', '/medical', '/instruction']
     default:
       return ['/']
   }
@@ -149,6 +150,7 @@ export function canAccessPath(
       path === '/faculty/medical' ||
       path === '/medical' ||
       path === '/reports' ||
+      path === '/instruction' ||
       path === '/students' ||
       path.startsWith('/students/')
     )
@@ -175,7 +177,13 @@ export function canAccessPath(
     ) {
       return true
     }
-    return path === '/' || path === '/student' || path === '/student/medical' || path === '/medical'
+    return (
+      path === '/' ||
+      path === '/student' ||
+      path === '/student/medical' ||
+      path === '/medical' ||
+      path === '/instruction'
+    )
   }
 
   return false

--- a/src/spms/components/Sidebar.tsx
+++ b/src/spms/components/Sidebar.tsx
@@ -50,9 +50,14 @@ export function Sidebar({ mobileOpen, desktopHidden }: SidebarProps) {
           <i className="bi bi-grid-1x2" /> Dashboard
         </NavLink>
         {isStudent ? (
-          <NavLink className={navClass} to="/medical">
-            <i className="bi bi-heart-pulse" /> Medical
-          </NavLink>
+          <>
+            <NavLink className={navClass} to="/medical">
+              <i className="bi bi-heart-pulse" /> Medical
+            </NavLink>
+            <NavLink className={navClass} to="/instruction">
+              <i className="bi bi-journal-text" /> Instruction
+            </NavLink>
+          </>
         ) : null}
         {!isStudent && (
           <>
@@ -101,6 +106,11 @@ export function Sidebar({ mobileOpen, desktopHidden }: SidebarProps) {
             {(role === 'admin' || role === 'faculty') && (
               <NavLink className={navClass} to="/reports">
                 <i className="bi bi-file-earmark-bar-graph" /> Reports
+              </NavLink>
+            )}
+            {(role === 'admin' || role === 'faculty') && (
+              <NavLink className={navClass} to="/instruction">
+                <i className="bi bi-journal-text" /> Instruction
               </NavLink>
             )}
           </>

--- a/src/spms/pages/InstructionModulePage.tsx
+++ b/src/spms/pages/InstructionModulePage.tsx
@@ -1,0 +1,391 @@
+import { useEffect, useMemo, useState } from 'react'
+import axios from 'axios'
+import { useAuth } from '../auth/AuthContext'
+
+type SyllabusRow = {
+  syllabus_id: number
+  title: string
+  description?: string
+  course_code?: string
+  is_archived?: number
+}
+
+type LessonRow = {
+  lesson_id: number
+  syllabus_id: number
+  title: string
+  content?: string
+  curriculum_unit?: string
+  week_number?: number | null
+  order_index: number
+  is_archived?: number
+}
+
+export function InstructionModulePage() {
+  const { user } = useAuth()
+  const canEdit = user?.role === 'admin' || user?.role === 'faculty'
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [syllabi, setSyllabi] = useState<SyllabusRow[]>([])
+  const [selectedId, setSelectedId] = useState<number | null>(null)
+  const [lessons, setLessons] = useState<LessonRow[]>([])
+  const [submitting, setSubmitting] = useState(false)
+
+  const [newSyllabus, setNewSyllabus] = useState({ title: '', course_code: '', description: '' })
+  const [newLesson, setNewLesson] = useState({ title: '', curriculum_unit: '', week_number: '', content: '' })
+
+  const selectedSyllabus = useMemo(
+    () => syllabi.find((row) => row.syllabus_id === selectedId) ?? null,
+    [syllabi, selectedId],
+  )
+
+  const fetchSyllabi = async () => {
+    const res = await axios.get<{ syllabi: SyllabusRow[] }>('/api/instruction/syllabi')
+    const rows = res.data.syllabi ?? []
+    setSyllabi(rows)
+    setSelectedId((prev) => prev ?? rows[0]?.syllabus_id ?? null)
+  }
+
+  const fetchLessons = async (syllabusId: number) => {
+    const res = await axios.get<{ lessons: LessonRow[] }>(`/api/instruction/syllabi/${syllabusId}/lessons`)
+    setLessons((res.data.lessons ?? []).sort((a, b) => a.order_index - b.order_index))
+  }
+
+  const loadAll = async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      await fetchSyllabi()
+    } catch (e: unknown) {
+      const msg = axios.isAxiosError(e) ? (e.response?.data as { message?: string } | undefined)?.message : undefined
+      setError(msg || 'Failed to load instruction data.')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    void loadAll()
+  }, [])
+
+  useEffect(() => {
+    if (!selectedId) {
+      setLessons([])
+      return
+    }
+    void fetchLessons(selectedId)
+  }, [selectedId])
+
+  const createSyllabus = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!canEdit) return
+    setError(null)
+    if (!newSyllabus.title.trim()) {
+      setError('Syllabus title is required.')
+      return
+    }
+    setSubmitting(true)
+    try {
+      await axios.post('/api/instruction/syllabi', {
+        title: newSyllabus.title.trim(),
+        course_code: newSyllabus.course_code.trim(),
+        description: newSyllabus.description.trim(),
+      })
+      setNewSyllabus({ title: '', course_code: '', description: '' })
+      await fetchSyllabi()
+    } catch (e: unknown) {
+      const msg = axios.isAxiosError(e) ? (e.response?.data as { message?: string } | undefined)?.message : undefined
+      setError(msg || 'Failed to create syllabus.')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  const createLesson = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!canEdit || !selectedId) return
+    setError(null)
+    if (!newLesson.title.trim()) {
+      setError('Lesson title is required.')
+      return
+    }
+    setSubmitting(true)
+    try {
+      await axios.post('/api/instruction/lessons', {
+        syllabus_id: selectedId,
+        title: newLesson.title.trim(),
+        curriculum_unit: newLesson.curriculum_unit.trim(),
+        week_number: newLesson.week_number ? Number(newLesson.week_number) : null,
+        content: newLesson.content.trim(),
+      })
+      setNewLesson({ title: '', curriculum_unit: '', week_number: '', content: '' })
+      await fetchLessons(selectedId)
+    } catch (e: unknown) {
+      const msg = axios.isAxiosError(e) ? (e.response?.data as { message?: string } | undefined)?.message : undefined
+      setError(msg || 'Failed to create lesson.')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  const saveCurriculum = async () => {
+    if (!canEdit || !selectedId) return
+    setSubmitting(true)
+    setError(null)
+    try {
+      await axios.put(`/api/instruction/syllabi/${selectedId}/curriculum`, {
+        lessons: lessons.map((row, idx) => ({
+          lesson_id: row.lesson_id,
+          order_index: idx + 1,
+          curriculum_unit: row.curriculum_unit ?? '',
+          week_number: row.week_number ?? null,
+        })),
+      })
+      await fetchLessons(selectedId)
+    } catch (e: unknown) {
+      const msg = axios.isAxiosError(e) ? (e.response?.data as { message?: string } | undefined)?.message : undefined
+      setError(msg || 'Failed to save curriculum order.')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  const moveLesson = (lessonId: number, dir: -1 | 1) => {
+    setLessons((prev) => {
+      const idx = prev.findIndex((x) => x.lesson_id === lessonId)
+      if (idx < 0) return prev
+      const nextIdx = idx + dir
+      if (nextIdx < 0 || nextIdx >= prev.length) return prev
+      const copy = [...prev]
+      const [item] = copy.splice(idx, 1)
+      copy.splice(nextIdx, 0, item)
+      return copy.map((row, i) => ({ ...row, order_index: i + 1 }))
+    })
+  }
+
+  const archiveSyllabus = async () => {
+    if (!canEdit || !selectedId) return
+    const ok = window.confirm('Archive this syllabus and all its lessons?')
+    if (!ok) return
+    setSubmitting(true)
+    try {
+      await axios.delete(`/api/instruction/syllabi/${selectedId}`)
+      setSelectedId(null)
+      await fetchSyllabi()
+    } catch (e: unknown) {
+      const msg = axios.isAxiosError(e) ? (e.response?.data as { message?: string } | undefined)?.message : undefined
+      setError(msg || 'Failed to archive syllabus.')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  const editSyllabus = async () => {
+    if (!canEdit || !selectedSyllabus) return
+    const title = window.prompt('Syllabus title', selectedSyllabus.title)
+    if (title === null) return
+    const course = window.prompt('Course code', selectedSyllabus.course_code ?? '')
+    if (course === null) return
+    const description = window.prompt('Description', selectedSyllabus.description ?? '')
+    if (description === null) return
+    setSubmitting(true)
+    try {
+      await axios.put(`/api/instruction/syllabi/${selectedSyllabus.syllabus_id}`, {
+        title: title.trim(),
+        course_code: course.trim(),
+        description: description.trim(),
+      })
+      await fetchSyllabi()
+    } catch (e: unknown) {
+      const msg = axios.isAxiosError(e) ? (e.response?.data as { message?: string } | undefined)?.message : undefined
+      setError(msg || 'Failed to update syllabus.')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  const archiveLesson = async (lessonId: number) => {
+    if (!canEdit || !selectedId) return
+    const ok = window.confirm('Archive this lesson?')
+    if (!ok) return
+    setSubmitting(true)
+    try {
+      await axios.delete(`/api/instruction/lessons/${lessonId}`)
+      await fetchLessons(selectedId)
+    } catch (e: unknown) {
+      const msg = axios.isAxiosError(e) ? (e.response?.data as { message?: string } | undefined)?.message : undefined
+      setError(msg || 'Failed to archive lesson.')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  const editLesson = async (row: LessonRow) => {
+    if (!canEdit) return
+    const title = window.prompt('Lesson title', row.title)
+    if (title === null) return
+    const unit = window.prompt('Curriculum unit', row.curriculum_unit ?? '')
+    if (unit === null) return
+    const weekRaw = window.prompt('Week number (optional)', row.week_number ? String(row.week_number) : '')
+    if (weekRaw === null) return
+    const content = window.prompt('Lesson content', row.content ?? '')
+    if (content === null) return
+    const weekNumber = weekRaw.trim() ? Number(weekRaw.trim()) : null
+    setSubmitting(true)
+    try {
+      await axios.put(`/api/instruction/lessons/${row.lesson_id}`, {
+        title: title.trim(),
+        curriculum_unit: unit.trim(),
+        week_number: weekNumber,
+        content: content.trim(),
+      })
+      if (selectedId) await fetchLessons(selectedId)
+    } catch (e: unknown) {
+      const msg = axios.isAxiosError(e) ? (e.response?.data as { message?: string } | undefined)?.message : undefined
+      setError(msg || 'Failed to update lesson.')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <div className="row g-4">
+      <div className="col-12 col-xl-4">
+        <div className="spms-card card border-0" style={{ borderRadius: 16, boxShadow: '0 4px 20px rgba(15, 23, 42, .06)' }}>
+          <div className="card-body">
+            <h6 className="fw-semibold mb-2">Syllabus</h6>
+            {canEdit ? (
+              <form onSubmit={createSyllabus} className="d-flex flex-column gap-2 mb-3">
+                <input className="form-control" placeholder="Syllabus title" value={newSyllabus.title} onChange={(e) => setNewSyllabus((v) => ({ ...v, title: e.target.value }))} disabled={submitting} />
+                <input className="form-control" placeholder="Course code (optional)" value={newSyllabus.course_code} onChange={(e) => setNewSyllabus((v) => ({ ...v, course_code: e.target.value }))} disabled={submitting} />
+                <textarea className="form-control" rows={3} placeholder="Description (optional)" value={newSyllabus.description} onChange={(e) => setNewSyllabus((v) => ({ ...v, description: e.target.value }))} disabled={submitting} />
+                <button type="submit" className="btn btn-primary btn-sm rounded-3" disabled={submitting}>Create syllabus</button>
+              </form>
+            ) : null}
+
+            {loading ? <div className="spms-muted small">Loading…</div> : null}
+            {!loading && syllabi.length === 0 ? <div className="spms-muted small">No syllabus available yet.</div> : null}
+            <div className="list-group">
+              {syllabi.map((row) => (
+                <button
+                  key={row.syllabus_id}
+                  type="button"
+                  className={`list-group-item list-group-item-action ${row.syllabus_id === selectedId ? 'active' : ''}`}
+                  onClick={() => setSelectedId(row.syllabus_id)}
+                >
+                  <div className="fw-semibold">{row.title}</div>
+                  <div className="small opacity-75">{row.course_code || 'No course code'}</div>
+                </button>
+              ))}
+            </div>
+            {canEdit && selectedId ? (
+              <div className="d-flex gap-2 mt-3">
+                <button type="button" className="btn btn-outline-secondary btn-sm rounded-3" onClick={() => void editSyllabus()} disabled={submitting}>
+                  Edit selected syllabus
+                </button>
+                <button type="button" className="btn btn-outline-warning btn-sm rounded-3" onClick={() => void archiveSyllabus()} disabled={submitting}>
+                  Archive selected syllabus
+                </button>
+              </div>
+            ) : null}
+          </div>
+        </div>
+      </div>
+
+      <div className="col-12 col-xl-8">
+        <div className="spms-card card border-0" style={{ borderRadius: 16, boxShadow: '0 4px 20px rgba(15, 23, 42, .06)' }}>
+          <div className="card-body">
+            <h6 className="fw-semibold mb-1">Lessons and Curriculum</h6>
+            <p className="spms-muted small mb-3">
+              {selectedSyllabus ? `${selectedSyllabus.title}${selectedSyllabus.course_code ? ` (${selectedSyllabus.course_code})` : ''}` : 'Select a syllabus to view lessons.'}
+            </p>
+
+            {canEdit && selectedId ? (
+              <form onSubmit={createLesson} className="row g-2 mb-3">
+                <div className="col-12 col-md-6">
+                  <input className="form-control" placeholder="Lesson title" value={newLesson.title} onChange={(e) => setNewLesson((v) => ({ ...v, title: e.target.value }))} disabled={submitting} />
+                </div>
+                <div className="col-6 col-md-3">
+                  <input className="form-control" placeholder="Curriculum unit" value={newLesson.curriculum_unit} onChange={(e) => setNewLesson((v) => ({ ...v, curriculum_unit: e.target.value }))} disabled={submitting} />
+                </div>
+                <div className="col-6 col-md-3">
+                  <input className="form-control" type="number" min={1} max={52} placeholder="Week #" value={newLesson.week_number} onChange={(e) => setNewLesson((v) => ({ ...v, week_number: e.target.value }))} disabled={submitting} />
+                </div>
+                <div className="col-12">
+                  <textarea className="form-control" rows={3} placeholder="Lesson content" value={newLesson.content} onChange={(e) => setNewLesson((v) => ({ ...v, content: e.target.value }))} disabled={submitting} />
+                </div>
+                <div className="col-12 d-flex gap-2">
+                  <button type="submit" className="btn btn-primary btn-sm rounded-3" disabled={submitting || !selectedId}>Add lesson</button>
+                  <button type="button" className="btn btn-outline-secondary btn-sm rounded-3" onClick={() => void saveCurriculum()} disabled={submitting || lessons.length === 0}>
+                    Save curriculum order
+                  </button>
+                </div>
+              </form>
+            ) : null}
+
+            {error ? (
+              <div className="alert alert-danger py-2">
+                <i className="bi bi-exclamation-circle me-2" />
+                {error}
+              </div>
+            ) : null}
+
+            <div className="table-responsive">
+              <table className="table table-hover align-middle mb-0">
+                <thead>
+                  <tr className="small spms-muted">
+                    <th>Order</th>
+                    <th>Lesson</th>
+                    <th>Curriculum</th>
+                    <th>Week</th>
+                    <th>Content</th>
+                    {canEdit ? <th className="text-end">Actions</th> : null}
+                  </tr>
+                </thead>
+                <tbody>
+                  {selectedId && lessons.length === 0 ? (
+                    <tr>
+                      <td colSpan={canEdit ? 6 : 5} className="py-3 spms-muted text-center">No lessons yet.</td>
+                    </tr>
+                  ) : null}
+                  {!selectedId ? (
+                    <tr>
+                      <td colSpan={canEdit ? 6 : 5} className="py-3 spms-muted text-center">Select a syllabus first.</td>
+                    </tr>
+                  ) : null}
+                  {lessons.map((row, idx) => (
+                    <tr key={row.lesson_id}>
+                      <td className="fw-semibold">{idx + 1}</td>
+                      <td className="fw-semibold">{row.title}</td>
+                      <td>{row.curriculum_unit || '—'}</td>
+                      <td>{row.week_number ?? '—'}</td>
+                      <td className="small">{row.content || '—'}</td>
+                      {canEdit ? (
+                        <td className="text-end">
+                          <div className="btn-group btn-group-sm">
+                            <button type="button" className="btn btn-outline-secondary" onClick={() => moveLesson(row.lesson_id, -1)} disabled={idx === 0}>
+                              <i className="bi bi-arrow-up" />
+                            </button>
+                            <button type="button" className="btn btn-outline-secondary" onClick={() => moveLesson(row.lesson_id, 1)} disabled={idx === lessons.length - 1}>
+                              <i className="bi bi-arrow-down" />
+                            </button>
+                            <button type="button" className="btn btn-outline-danger" onClick={() => void archiveLesson(row.lesson_id)} disabled={submitting}>
+                              Archive
+                            </button>
+                            <button type="button" className="btn btn-outline-primary" onClick={() => void editLesson(row)} disabled={submitting}>
+                              Edit
+                            </button>
+                          </div>
+                        </td>
+                      ) : null}
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/spms/router.tsx
+++ b/src/spms/router.tsx
@@ -23,6 +23,7 @@ import { MedicalModulePage } from './pages/MedicalModulePage'
 import { StudentMedicalSubmitPage } from './pages/StudentMedicalSubmitPage'
 import { StudentLegacyProfileRedirect } from './pages/StudentLegacyProfileRedirect'
 import { UsersPage } from './pages/UsersPage'
+import { InstructionModulePage } from './pages/InstructionModulePage'
 import { NotFoundPage } from './pages/NotFoundPage'
 import { LoginPage } from './pages/LoginPage'
 import { Link } from 'react-router-dom'
@@ -139,6 +140,11 @@ const sectionsHandle: PageMeta = {
 const usersHandle: PageMeta = {
   title: 'Account Management',
   subtitle: 'Create and manage user accounts',
+}
+
+const instructionHandle: PageMeta = {
+  title: 'Instruction Module',
+  subtitle: 'Manage syllabus, lessons, and curriculum',
 }
 
 const notFoundHandle: PageMeta = {
@@ -361,6 +367,15 @@ export const spmsRouter = createBrowserRouter([
           </RoleProtectedRoute>
         ),
         handle: usersHandle,
+      },
+      {
+        path: '/instruction',
+        element: (
+          <RoleProtectedRoute allowedRoles={['admin', 'faculty', 'student']}>
+            <InstructionModulePage />
+          </RoleProtectedRoute>
+        ),
+        handle: instructionHandle,
       },
       { path: '*', element: <NotFoundPage />, handle: notFoundHandle },
     ],


### PR DESCRIPTION
Implement an end-to-end Instruction module with role-based permissions so registrar and faculty can manage syllabus, lessons, and curriculum ordering while students have view-only access.

